### PR TITLE
Fix: GitHub deprecation error for access token use

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
-name: 'Create Release with Specified Branch'
+name: 'Create Branch-specific Release'
 description: 'Create a release from a specified branch'
-author: 'Alessandro Aiezza'
+author: 'Jerez Bain'
 
 branding:
   icon: 'tag'
-  color: 'green'
+  color: 'blue'
 
 inputs:
   release_branch:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ if [ "${CREATE_RELEASE}" = "true" ] || [ "${CREATE_RELEASE}" = true ]; then
                     --argjson p "$PRERELEASE" \
                     '{tag_name: $tn, target_commitish: $tc, name: $n, body: $b, draft: $d, prerelease: $p}' )
   echo ${JSON_STRING}
-  OUTPUT=$(curl -s --data "${JSON_STRING}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?access_token=${GITHUB_TOKEN}")
+  OUTPUT=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" --data "${JSON_STRING}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases")
   echo ${OUTPUT} | jq
 fi;
 


### PR DESCRIPTION
```
{
  "message": "Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param",
  "documentation_url": "https://docs.github.com/v3/#oauth2-token-sent-in-a-header"
}
```