### PR TITLE
Fix Query Param Deprecation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ if [ "${CREATE_RELEASE}" = "true" ] || [ "${CREATE_RELEASE}" = true ]; then
                     --argjson p "$PRERELEASE" \
                     '{tag_name: $tn, target_commitish: $tc, name: $n, body: $b, draft: $d, prerelease: $p}' )
   echo ${JSON_STRING}
-  OUTPUT=$(curl -s --data "${JSON_STRING}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?access_token=${GITHUB_TOKEN}")
+  OUTPUT=$(curl -s --data "${JSON_STRING}" -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases")
   echo ${OUTPUT} | jq
 fi;
 


### PR DESCRIPTION
Fixed the deprecation of the API Auth through query parameters as noted in https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

This fixes the following error log that prevents branch / release creation
```
{
  "message": "Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param",
  "documentation_url": "https://docs.github.com/v3/#oauth2-token-sent-in-a-header"
}
```

I see the other pull request changes authors, this one just fixes the error.